### PR TITLE
Query for “SET_TO_PRIVATE-Switch”

### DIFF
--- a/switch_repo_public_private.ps1
+++ b/switch_repo_public_private.ps1
@@ -2,7 +2,6 @@
 $Global:GITHUB_USER = ""
 $Global:GITHUB_TOKEN = ""
 $Global:REPOS_VISIBILITY_TYPE = "public" # which type of repos to convert: public or private
-$Global:SET_TO_PRIVATE = "true" # if REPOS_VISIBILITY_TYPE = "public" then value must be "true", if REPOS_VISIBILITY_TYPE = "private" then value must be "false"
 
 #start running
 [GitHub]::reposToPrivate()
@@ -14,6 +13,14 @@ class GitHub {
 
         $jsonStr = ""
         $pageNo = 1
+        
+        # if REPOS_VISIBILITY_TYPE = "public" then value must be "true", if REPOS_VISIBILITY_TYPE = "private" then value must be "false"
+        if ($Global:REPOS_VISIBILITY_TYPE -eq "public") {
+            $Global:SET_TO_PRIVATE = "true"
+        }
+        else {
+            $Global:SET_TO_PRIVATE = "false"
+        }
 
         Do {
         


### PR DESCRIPTION
Improves the SET_TO_PRIVATE variable so that the user does not have to manually decide which “mode” to choose.

https://github.com/akicsike/powershell_switch_repos_visibility_public_private/issues/4