### PR TITLE
Catch Errors during api-requests

### DIFF
--- a/switch_repo_public_private.ps1
+++ b/switch_repo_public_private.ps1
@@ -10,7 +10,7 @@ $Global:SET_TO_PRIVATE = "true" # if REPOS_VISIBILITY_TYPE = "public" then value
 
 class GitHub {
 
-    static [void] reposToPrivate(){
+    static [void] reposToPrivate() {
 
         $jsonStr = ""
         $pageNo = 1
@@ -27,16 +27,16 @@ class GitHub {
         
 
     }
-    static [string] getRepos($pageNo){
+    static [string] getRepos($pageNo) {
 
         $endpoint = "https://api.github.com/user/repos?visibility=$($Global:REPOS_VISIBILITY_TYPE)&page=$($pageNo)"
         $resp = [GitHub]::callApi($endpoint, "GET", $false, @{})
         
         return $resp
     }
-    static [void] handleJsonForPrivate($json){
+    static [void] handleJsonForPrivate($json) {
 
-        foreach($obj in $json){
+        foreach ($obj in $json) {
 
             Write-Host "endpoint: $($obj.url)"
             $endpoint = $obj.url
@@ -47,34 +47,41 @@ class GitHub {
         }
 
     }
-    static [string] setRepoToPrivate($endpoint){
+    static [string] setRepoToPrivate($endpoint) {
 
-        $postParams = @{"private"="$($Global:SET_TO_PRIVATE)"}
+        $postParams = @{"private" = "$($Global:SET_TO_PRIVATE)" }
         $resp = [GitHub]::callApi($endpoint, "PATCH", $true, $postParams)
 
         return $resp
     }
-    static [string] b64Authentication(){
+    static [string] b64Authentication() {
 
-        $AuthBytes  = [System.Text.Encoding]::Ascii.GetBytes("$($Global:GITHUB_USER):$Global:GITHUB_TOKEN")
+        $AuthBytes = [System.Text.Encoding]::Ascii.GetBytes("$($Global:GITHUB_USER):$Global:GITHUB_TOKEN")
         return [Convert]::ToBase64String($AuthBytes)
 
     }
-    static [string] callApi([string]$endpoint, [string]$methodType, [bool]$hasPostParams, [hashtable]$postParams){
+    static [string] callApi([string]$endpoint, [string]$methodType, [bool]$hasPostParams, [hashtable]$postParams) {
+        
+        try {
+            $resp = ""
 
-        $resp = ""
+            if ($hasPostParams) {
+                $resp = Invoke-WebRequest -Uri $endpoint -Headers @{"Authorization" = "Basic $([GitHub]::b64Authentication())"; "Accept" = "application/vnd.github.v3+json" } -Method $methodType -Body ($postParams | ConvertTo-Json)
+            }
+            else {
+                $resp = Invoke-WebRequest -Uri $endpoint -Headers @{"Authorization" = "Basic $([GitHub]::b64Authentication())"; "Accept" = "application/vnd.github.v3+json" } -Method $methodType
+            }
 
-        if($hasPostParams){
-            $resp = Invoke-WebRequest -Uri $endpoint -Headers @{"Authorization"="Basic $([GitHub]::b64Authentication())"; "Accept"="application/vnd.github.v3+json"} -Method $methodType -Body ($postParams|ConvertTo-Json)
-        } else {
-            $resp = Invoke-WebRequest -Uri $endpoint -Headers @{"Authorization"="Basic $([GitHub]::b64Authentication())"; "Accept"="application/vnd.github.v3+json"} -Method $methodType
+            return $resp
         }
-
-        return $resp
+        catch {
+            Write-Host "Error: $($_.Exception.Message)"
+            return ""
+        } 
+        
     }
-    static [Object] convertJson($jsonStr){
+    static [Object] convertJson($jsonStr) {
     
-        #Write-Host "jsonStr: $($jsonStr)"
         $json = $jsonStr | ConvertFrom-JSON
 
         return $json


### PR DESCRIPTION
This ensures that the whole Powershell is not terminated if there are one (or more) errors in the API request. Repos that cannot be processed are skipped with this.

Should be fixing:
https://github.com/akicsike/powershell_switch_repos_visibility_public_private/issues/1
https://github.com/akicsike/powershell_switch_repos_visibility_public_private/issues/2
https://github.com/akicsike/powershell_switch_repos_visibility_public_private/issues/3

I also cleaned up a bit. 😉